### PR TITLE
Validate dependencies refactor

### DIFF
--- a/ck
+++ b/ck
@@ -6,6 +6,7 @@ trap "exit 1" TERM
 export TOP_PID=$$
 
 DIR=$(dirname $(readlink $0 || echo $0))
+. $DIR/lib/logging.sh
 . $DIR/lib/validateDeps.sh
 . $DIR/lib/common.sh
 SUBCOMMANDS=$(ls $DIR/subcommands)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,93 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
 
-VERBOSITY=0
-AUTO_HIBERNATION=true
-COMMAND_VERBOSITY=2
-OUTPUT_VERBOSITY=3
-CLUSTER_WAIT_MAX=60
-HIBERNATE_WAIT_MAX=15
-CLUSTERPOOL_CONTEXT_NAME=ck
-
-VERIFIED_CONTEXTS=()
-
-CLUSTERCLAIM_CUSTOM_COLUMNS="\
-NAME:.metadata.name,\
-CLUSTER:.spec.namespace,\
-POWERSTATE:PLACEHOLDER,\
-LOCKS:.metadata.annotations.open-cluster-management\.io/cluster-keeper-locks,\
-SCHEDULE:.metadata.annotations.open-cluster-management\.io/cluster-keeper-hibernation,\
-HIBERNATE:PLACEHOLDER,\
-LIFETIME:.spec.lifetime,\
-AGE:.metadata.creationTimestamp"
-
-source ${DIR}/lib/logging.sh
-
-# Use to log regular commands
-# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
-# - command output is logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
-# - stderr is not suppressed; failure exits the script
-function cmd {
-  logCommand "$@"
-  OUTPUT=$("$@")
-  logOutput "$OUTPUT"
-}
-
-# Use to log regular commands that can fail
-# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
-# - command output is logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
-# - stderr is suppressed and a failure will not exit the script
-function cmdTry {
-  set +e
-  logCommand "$@"
-  OUTPUT=$("$@" 2>&1)
-  logOutput "$OUTPUT"
-  set -e
-}
-
-# Use to log command substitutions or regular commands when output should be displayed to the user
-# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
-# - command output is logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
-# - stderr is not suppressed; failure exits the script
-# - stdout is "returned"
-function sub {
-  logCommand "$@"
-  OUTPUT=$("$@")
-  logOutput "$OUTPUT"
-  echo "$OUTPUT"
-}
-
-# Use to log command substitutions when only interested in exit code
-# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
-# - command stdout and stderr are logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
-# - stderr is suppressed and does not fail the script; "returns" exit code
-function subRC {
-  set +e
-  logCommand $@
-  OUTPUT=$("$@" 2>&1)
-  RC=$?
-  logOutput "$OUTPUT"
-  set -e
-  echo -n $RC
-}
-
-# Use to log command substitutions, ignoring errors
-# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
-# - command output logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
-# - stderr is not suppressed
-# - stdout is "returned" if command exits successfully
-function subIf {
-  set +e
-  logCommand $@
-  OUTPUT=$("$@")
-  RC=$?
-  logOutput "$OUTPUT"
-  if [[ $RC -eq 0 ]]
-  then
-    echo $OUTPUT
-  fi
-  set -e
-}
-
 # nd = new directory
 function nd() {
   pushd $1 > /dev/null
@@ -97,13 +9,6 @@ function nd() {
 function od() {
   popd > /dev/null
 }
-
-function notConfigured {
-  fatal "user.env file not found"
-}
-
-[[ -f $DIR/user.env ]] || notConfigured
-. $DIR/user.env
 
 function notLoggedIn {
   error "not logged in to $CLUSTERPOOL_CLUSTER"

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -1,5 +1,24 @@
-#!/usr/bin/env bash
 # Copyright Contributors to the Open Cluster Management project
+
+VERBOSITY=0
+AUTO_HIBERNATION=true
+COMMAND_VERBOSITY=2
+OUTPUT_VERBOSITY=3
+CLUSTER_WAIT_MAX=60
+HIBERNATE_WAIT_MAX=15
+CLUSTERPOOL_CONTEXT_NAME=ck
+
+VERIFIED_CONTEXTS=()
+
+CLUSTERCLAIM_CUSTOM_COLUMNS="\
+NAME:.metadata.name,\
+CLUSTER:.spec.namespace,\
+POWERSTATE:PLACEHOLDER,\
+LOCKS:.metadata.annotations.open-cluster-management\.io/cluster-keeper-locks,\
+SCHEDULE:.metadata.annotations.open-cluster-management\.io/cluster-keeper-hibernation,\
+HIBERNATE:PLACEHOLDER,\
+LIFETIME:.spec.lifetime,\
+AGE:.metadata.creationTimestamp"
 
 function abort {
   kill -s TERM $TOP_PID
@@ -39,4 +58,70 @@ function fatal {
 # Use to silence output when not using "return" value from a function
 function ignoreOutput {
   "$@" > /dev/null
+}
+
+# Use to log regular commands
+# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
+# - command output is logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
+# - stderr is not suppressed; failure exits the script
+function cmd {
+  logCommand "$@"
+  OUTPUT=$("$@")
+  logOutput "$OUTPUT"
+}
+
+# Use to log regular commands that can fail
+# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
+# - command output is logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
+# - stderr is suppressed and a failure will not exit the script
+function cmdTry {
+  set +e
+  logCommand "$@"
+  OUTPUT=$("$@" 2>&1)
+  logOutput "$OUTPUT"
+  set -e
+}
+
+# Use to log command substitutions or regular commands when output should be displayed to the user
+# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
+# - command output is logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
+# - stderr is not suppressed; failure exits the script
+# - stdout is "returned"
+function sub {
+  logCommand "$@"
+  OUTPUT=$("$@")
+  logOutput "$OUTPUT"
+  echo "$OUTPUT"
+}
+
+# Use to log command substitutions when only interested in exit code
+# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
+# - command stdout and stderr are logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
+# - stderr is suppressed and does not fail the script; "returns" exit code
+function subRC {
+  set +e
+  logCommand $@
+  OUTPUT=$("$@" 2>&1)
+  RC=$?
+  logOutput "$OUTPUT"
+  set -e
+  echo -n $RC
+}
+
+# Use to log command substitutions, ignoring errors
+# - command is logged to stderr if VERBOSITY is COMMAND_VERBOSITY or higher
+# - command output logged to stderr if VERBOSITY is OUTPUT_VERBOSITY or higher
+# - stderr is not suppressed
+# - stdout is "returned" if command exits successfully
+function subIf {
+  set +e
+  logCommand $@
+  OUTPUT=$("$@")
+  RC=$?
+  logOutput "$OUTPUT"
+  if [[ $RC -eq 0 ]]
+  then
+    echo $OUTPUT
+  fi
+  set -e
 }

--- a/lib/validateDeps.sh
+++ b/lib/validateDeps.sh
@@ -1,13 +1,14 @@
-#!/usr/bin/env bash
 # Copyright Contributors to the Open Cluster Management project
 
-source ${DIR}/lib/logging.sh
+# Validate configuration file is present and load
+[[ -f $DIR/user.env ]] || fatal "user.env file not found"
+. $DIR/user.env
 
 # Validate bash version is 4 or greater
 if [ "${BASH_VERSINFO:-0}" -lt 4 ]
 then
-  error "DEPENDENCY NOT MET. bash version 4 or greater is required to run this tool. Found version ${BASH_VERSION}"
-  verbose 0 "On MacOS install with \"brew install bash\".  This bash must be first in your path, but need not be '/bin/bash' or your default login shell."
+  error "bash version 4 or greater is required to run this tool. Found version ${BASH_VERSION}"
+  verbose 0 "On macOS install with \"brew install bash\".  This bash must be first in your path, but need not be '/bin/bash' or your default login shell."
   abort
 fi
 
@@ -17,7 +18,7 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 if [ "${OS}" == "darwin" ]; then
     if [ ! -x "$(command -v jq)"  ]; then
        error "jq is required, but not found."
-       verbose 0 "On MacOS install with \"brew install jq\" and try again."
+       verbose 0 "On macOS install with \"brew install jq\" and try again."
        abort
     fi
 fi
@@ -27,7 +28,7 @@ fi
 if [ "${OS}" == "darwin" ]; then
     if [ ! -x "$(command -v gsed)"  ]; then
        error "gsed is required, but not found."
-       verbose 0 "On MacOS install with \"brew install gnu-sed\" and try again."
+       verbose 0 "On macOS install with \"brew install gnu-sed\" and try again."
        abort
     fi
 fi

--- a/lib/validateDeps.sh
+++ b/lib/validateDeps.sh
@@ -1,5 +1,15 @@
 # Copyright Contributors to the Open Cluster Management project
 
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+function macHint {
+  local package=$1
+  local extra=$2
+  if [ "${OS}" == "darwin" ]; then
+    verbose 0 "Install with \"brew install ${package}\" and try again. ${extra}"
+  fi
+}
+
+
 # Validate configuration file is present and load
 [[ -f $DIR/user.env ]] || fatal "user.env file not found"
 . $DIR/user.env
@@ -8,27 +18,24 @@
 if [ "${BASH_VERSINFO:-0}" -lt 4 ]
 then
   error "bash version 4 or greater is required to run this tool. Found version ${BASH_VERSION}"
-  verbose 0 "On macOS install with \"brew install bash\".  This bash must be first in your path, but need not be '/bin/bash' or your default login shell."
+  macHint bash "This bash must be first in your path but need not be '/bin/bash' or your default login shell."
   abort
 fi
 
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-
 # Validate jq is installed
-if [ "${OS}" == "darwin" ]; then
-    if [ ! -x "$(command -v jq)"  ]; then
-       error "jq is required, but not found."
-       verbose 0 "On macOS install with \"brew install jq\" and try again."
-       abort
-    fi
+if [ ! -x "$(command -v jq)"  ]; then
+    error "jq is required but not found."
+    macHint jq
+    abort
 fi
 
-
-# Validate gsed is installed
+# Validate sed/gsed is installed
+SED=sed
 if [ "${OS}" == "darwin" ]; then
-    if [ ! -x "$(command -v gsed)"  ]; then
-       error "gsed is required, but not found."
-       verbose 0 "On macOS install with \"brew install gnu-sed\" and try again."
-       abort
-    fi
+  SED=gsed
+fi
+if [ ! -x "$(command -v $SED)"  ]; then
+    error "$SED is required but not found."
+    macHint gnu-sed
+    abort
 fi


### PR DESCRIPTION
@jlpadilla This was hard to describe in a review, so I just created this PR against your PR.

I agree that `common.sh` was getting long, but I didn't like how `logging.sh` was sourced twice, and in once case some of the variables it depends on would not be defined yet.

Also moved the check/sourcing of the user configuration file to your `validateDeps.sh` file.

A few tweaks to the messages as well, and support all the checks on Linux.